### PR TITLE
Use offsets

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -60,32 +60,29 @@ void solve_bignum_recursive(int cur_row, int cur_col, int sides, bool* visited, 
     mpz_t adder;
     mpz_init(adder);
 
-    for(int row=0; row < sides; row++) {
-        for(int col=0; col < sides; col++) {
-            // Make sure cell at row&col is unvisited
+    int row, col;
+    set_true(visited, sides, cur_row, cur_col);
+    for(int row_offset=-1; row_offset <= 1; row_offset++) {
+        row = cur_row + row_offset;
+        for(int col_offset=-1; col_offset <= 1; col_offset++) {
+            col = cur_col + col_offset;
+            if(col < 0 || row < 0 || col >= sides || row >= sides) {
+                continue;
+            }
+            if(row_offset == 0 && col_offset == 0) {
+                continue;
+            }
             if(get_visited(visited, sides, row, col) == true) {
                 continue;
             }
-            // Make sure cell at row&col is a neighbor
-            if(abs(cur_row - row) > 1) {
-                continue;
-            }
-            if(abs(cur_col - col) > 1) {
-                continue;
-            }
-            if(row == cur_row && col == cur_col) {
-                continue;
-            }
-
             // Code below this is only called for unvisited neighbors
             mpz_set(adder, old_sum);
-            set_true(visited, sides, cur_row, cur_col);
             solve_bignum_recursive(row, col, sides, visited, adder);
-            set_false(visited, sides, cur_row, cur_col);
             mpz_add(sum, sum, adder);
         }
     }
     mpz_clear(adder);
     mpz_clear(old_sum);
+    set_false(visited, sides, cur_row, cur_col);
     return;
 }

--- a/solver.c
+++ b/solver.c
@@ -71,23 +71,20 @@ unsigned long long solve_recursive(int cur_row, int cur_col, int sides, bool* vi
 
     set_true(visited, sides, cur_row, cur_col);
     bool early_return = true;
-    for(int row=0; row < sides; row++) {
-        for(int col=0; col < sides; col++) {
-            // Make sure cell at row&col is unvisited
+    int row, col;
+    for(int row_offset=-1; row_offset <= 1; row_offset++) {
+        row = cur_row + row_offset;
+        for(int col_offset=-1; col_offset <= 1; col_offset++) {
+            col = cur_col + col_offset;
+            if(col < 0 || row < 0 || col >= sides || row >= sides) {
+                continue;
+            }
+            if(row_offset == 0 && col_offset == 0) {
+                continue;
+            }
             if(get_visited(visited, sides, row, col) == true) {
                 continue;
             }
-            // Make sure cell at row&col is a neighbor
-            if(abs(cur_row - row) > 1) {
-                continue;
-            }
-            if(abs(cur_col - col) > 1) {
-                continue;
-            }
-            if(row == cur_row && col == cur_col) {
-                continue;
-            }
-
             // Code below this is only called for unvisited neighbors
             early_return = false;
             sum += (solve_recursive(row, col, sides, visited, old_sum));

--- a/solver.c
+++ b/solver.c
@@ -2,7 +2,7 @@
 
 unsigned long long solve(int sides, bool quiet) {
     unsigned long long sum = 0;
-    unsigned long long adder = 0;
+    unsigned long long adder = 1;
     int use_rows = sides / 2 > 1 ? sides / 2 : 1;
     int use_cols = sides / 2 > 1 ? sides / 2 : 1;
     bool sides_even = (sides % 2 == 0);
@@ -69,9 +69,8 @@ void print_board(bool* board, int sides) {
 unsigned long long solve_recursive(int cur_row, int cur_col, int sides, bool* visited, unsigned long long sum) {
     unsigned long long old_sum = sum;
 
-    set_true(visited, sides, cur_row, cur_col);
-    bool early_return = true;
     int row, col;
+    set_true(visited, sides, cur_row, cur_col);
     for(int row_offset=-1; row_offset <= 1; row_offset++) {
         row = cur_row + row_offset;
         for(int col_offset=-1; col_offset <= 1; col_offset++) {
@@ -86,15 +85,11 @@ unsigned long long solve_recursive(int cur_row, int cur_col, int sides, bool* vi
                 continue;
             }
             // Code below this is only called for unvisited neighbors
-            early_return = false;
             sum += (solve_recursive(row, col, sides, visited, old_sum));
         }
     }
 
     set_false(visited, sides, cur_row, cur_col);
-    if(early_return) {
-        return(1);
-    }
     return(sum);
 }
 


### PR DESCRIPTION
Instead of examining the whole board and bailing if we're not on a neighbor, use offsets around the current cell and bail if cur + offset is off of the board.

```
1 sides:
A board with 1 sides has 1 possible solutions
0.00user 0.00system 0:00.00elapsed 0%CPU (0avgtext+0avgdata 1344maxresident)k
0inputs+0outputs (0major+79minor)pagefaults 0swaps

2 sides:
A board with 2 sides has 64 possible solutions
0.00user 0.00system 0:00.00elapsed 0%CPU (0avgtext+0avgdata 1344maxresident)k
0inputs+0outputs (0major+79minor)pagefaults 0swaps

3 sides:
A board with 3 sides has 10305 possible solutions
0.00user 0.00system 0:00.00elapsed 0%CPU (0avgtext+0avgdata 1328maxresident)k
0inputs+0outputs (0major+78minor)pagefaults 0swaps

4 sides:
A board with 4 sides has 12029640 possible solutions
0.60user 0.00system 0:00.60elapsed 98%CPU (0avgtext+0avgdata 1220maxresident)k
0inputs+0outputs (0major+77minor)pagefaults 0swaps
```
