### PR TITLE
Add option to to calculate paths for a single cell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ LIBS=
 GMP=-lgmp
 BIN=boggle_paths
 PROFILE_FLAGS=-q
-all: clean bignum.o solver.o main.o
-	$(CC) $(CFLAGS) -o $(BIN) bignum.o solver.o main.o $(LIBS) $(GMP)
+all: clean bignum.o solver.o main.o helper.o
+	$(CC) $(CFLAGS) -o $(BIN) bignum.o solver.o main.o helper.o $(LIBS) $(GMP)
 
 main.o:
 	$(CC) $(CFLAGS) -c -o main.o main.c $(LIBS)
@@ -15,6 +15,9 @@ solver.o:
 
 bignum.o:
 	$(CC) $(CFLAGS) -c -o bignum.o bignum.c $(LIBS)
+
+helper.o:
+	$(CC) $(CFLAGS) -c -o helper.o helper.c $(LIBS)
 
 clean:
 	-rm *.o $(BIN)

--- a/bignum.c
+++ b/bignum.c
@@ -1,6 +1,17 @@
 #include "bignum.h"
 #include "helper.h"
 
+void solve_bignum_single(int row, int col, int sides, bool quiet, mpz_t result) {
+    mpz_set_ui(result, 1);
+    bool* visited = calloc(sides*sides, sizeof(bool));
+    if(!quiet) {
+        printf("Solving with bignums for (%d, %d) on a %dx%d grid...\n",col+1, row+1, sides, sides);
+    }
+    solve_bignum_recursive(row, col, sides, visited, result);
+    free(visited);
+    return;
+}
+
 void solve_bignum(int sides, bool quiet, mpz_t result) {
     mpz_set_ui(result, 0);
     mpz_t adder;
@@ -17,17 +28,16 @@ void solve_bignum(int sides, bool quiet, mpz_t result) {
     if(!quiet) {
         printf("Solving with bignums for %dx%d grid...\n", sides, sides);
     }
-    bool* visited = calloc(sides*sides, sizeof(bool));
     for(int row = 0; row < use_rows; row++) {
         for(int col = 0; col < use_cols; col++) {
             if(sides_large_odd && (row == (use_rows-1) && col != (use_cols-1))) {
                 continue;
             }
-            mpz_set_ui(adder, 1);
-            memset(visited, 0, sizeof(bool) * sides * sides);
-            solve_bignum_recursive(row, col, sides, visited, adder);
+            solve_bignum_single(row, col, sides, quiet, adder);
             if(!quiet) {
-                printf("\tSolved square at row %d, column %d: %s\n", row+1, col+1, mpz_get_str(NULL, 10, adder));
+                char* out_string = mpz_get_str(NULL, 10, adder);
+                printf("\tSolved square at row %d, column %d: %s\n", row+1, col+1, out_string);
+                free(out_string);
             }
             if(sides_even) {
                 if(!quiet) {
@@ -50,7 +60,6 @@ void solve_bignum(int sides, bool quiet, mpz_t result) {
         }
     }
     mpz_clear(adder);
-    free(visited);
     return;
 }
 

--- a/bignum.c
+++ b/bignum.c
@@ -1,5 +1,5 @@
 #include "bignum.h"
-#include "solver.h"
+#include "helper.h"
 
 void solve_bignum(int sides, bool quiet, mpz_t result) {
     mpz_set_ui(result, 0);

--- a/bignum.c
+++ b/bignum.c
@@ -16,45 +16,21 @@ void solve_bignum(int sides, bool quiet, mpz_t result) {
     mpz_set_ui(result, 0);
     mpz_t adder;
     mpz_init(adder);
-    int use_rows = sides / 2 > 1 ? sides / 2 : 1;
-    int use_cols = sides / 2 > 1 ? sides / 2 : 1;
-    bool sides_even = (sides % 2 == 0);
-    bool sides_large_odd = (!sides_even && sides > 1);
-    if(sides_large_odd){
-      use_rows += 1;
-      use_cols += 1;
-    }
 
     if(!quiet) {
         printf("Solving with bignums for %dx%d grid...\n", sides, sides);
     }
-    for(int row = 0; row < use_rows; row++) {
-        for(int col = 0; col < use_cols; col++) {
-            if(sides_large_odd && (row == (use_rows-1) && col != (use_cols-1))) {
+    for(int row = 0; row < sides; row++) {
+        for(int col = 0; col < sides; col++) {
+            if(is_duplicate(row, col, sides)) {
                 continue;
             }
             solve_bignum_single(row, col, sides, quiet, adder);
+            mpz_mul_si(adder, adder, multiplier_for(row, col, sides, quiet));
             if(!quiet) {
                 char* out_string = mpz_get_str(NULL, 10, adder);
                 printf("\tSolved square at row %d, column %d: %s\n", row+1, col+1, out_string);
                 free(out_string);
-            }
-            if(sides_even) {
-                if(!quiet) {
-                    printf("\t\tEven sides; square will be used four times\n");
-                }
-                mpz_mul_ui(adder, adder, 4);
-            } else if(sides_large_odd) {
-                if(row != use_rows-1 || col != use_cols-1) {
-                    if(!quiet) {
-                        printf("\t\tOdd sides; square will be used four times\n");
-                    }
-                    mpz_mul_ui(adder, adder, 4);
-                } else {
-                    if(!quiet){
-                        printf("\t\tCenter square is only used once\n");
-                    }
-                }
             }
             mpz_add(result, result, adder);
         }

--- a/bignum.h
+++ b/bignum.h
@@ -6,5 +6,6 @@
 #include <string.h>
 #include <gmp.h>
 void solve_bignum(int sides, bool quiet, mpz_t result);
+void solve_bignum_single(int row, int col, int sides, bool quiet, mpz_t result);
 void solve_bignum_recursive(int row, int col, int sides, bool* visited, mpz_t sum);
 #endif

--- a/helper.c
+++ b/helper.c
@@ -44,22 +44,6 @@ int multiplier_for(int row, int col, int sides, bool quiet) {
     return 1;
 }
 
-void print_board(bool* board, int sides) {
-    for(int row=0; row < sides; row++) {
-        printf("|");
-        for(int col=0; col < sides; col++) {
-            if(get_visited(board, sides, row, col)) {
-                printf("X");
-            } else {
-                printf(" ");
-            }
-            printf("|");
-        }
-        printf("\n");
-    }
-    printf("\n");
-}
-
 void set_true(bool* board, int sides, int row, int col) {
     set_val(board, sides, row, col, true);
 }

--- a/helper.c
+++ b/helper.c
@@ -1,0 +1,77 @@
+#include "helper.h"
+
+bool is_duplicate(int row, int col, int sides) {
+    int use_rows = sides / 2 > 1 ? sides / 2 : 1;
+    int use_cols = sides / 2 > 1 ? sides / 2 : 1;
+    bool sides_even = (sides % 2 == 0);
+    bool sides_large_odd = (!sides_even && sides > 1);
+    if(sides_large_odd){
+      use_rows += 1;
+      use_cols += 1;
+    }
+    if(row >= use_rows || col >= use_cols) {
+        return true;
+    }
+    if(sides_large_odd && (row == (use_rows-1) && col != (use_cols-1))) {
+        return true;
+    }
+    return false;
+}
+
+int multiplier_for(int row, int col, int sides, bool quiet) {
+    int use_rows = sides / 2 > 1 ? sides / 2 : 1;
+    int use_cols = sides / 2 > 1 ? sides / 2 : 1;
+    bool sides_even = (sides % 2 == 0);
+    bool sides_large_odd = (!sides_even && sides > 1);
+    if(sides_even) {
+        if(!quiet) {
+            printf("\t\tEven sides; square will be used four times\n");
+        }
+        return 4;
+    } else if(sides_large_odd) {
+        if(row != use_rows-1 || col != use_cols-1) {
+            if(!quiet) {
+                printf("\t\tOdd sides; square will be used four times\n");
+            }
+            return 4;
+        } else {
+            if(!quiet) {
+                printf("\t\tCenter square is only used once\n");
+            }
+            return 1;
+        }
+    }
+    return 1;
+}
+
+void print_board(bool* board, int sides) {
+    for(int row=0; row < sides; row++) {
+        printf("|");
+        for(int col=0; col < sides; col++) {
+            if(get_visited(board, sides, row, col)) {
+                printf("X");
+            } else {
+                printf(" ");
+            }
+            printf("|");
+        }
+        printf("\n");
+    }
+    printf("\n");
+}
+
+void set_true(bool* board, int sides, int row, int col) {
+    set_val(board, sides, row, col, true);
+}
+
+void set_false(bool* board, int sides, int row, int col) {
+    set_val(board, sides, row, col, false);
+}
+
+void set_val(bool* board, int sides, int row, int col, bool val) {
+    board[(sides * row) + col] = val;
+}
+
+bool get_visited(bool* board, int sides, int row, int col) {
+    return( board[(sides * row) + col] );
+}

--- a/helper.c
+++ b/helper.c
@@ -29,7 +29,7 @@ int multiplier_for(int row, int col, int sides, bool quiet) {
         }
         return 4;
     } else if(sides_large_odd) {
-        if(row != use_rows-1 || col != use_cols-1) {
+        if(row != use_rows || col != use_cols) {
             if(!quiet) {
                 printf("\t\tOdd sides; square will be used four times\n");
             }

--- a/helper.h
+++ b/helper.h
@@ -4,10 +4,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-void set_true(bool*, int, int, int);
-void set_false(bool*, int, int, int);
-void set_val(bool*, int, int, int, bool);
-bool get_visited(bool*, int, int, int);
+void set_true(bool* board, int sides, int row, int col);
+void set_false(bool* board, int sides, int row, int col);
+void set_val(bool* board, int sides, int row, int col, bool val);
+bool get_visited(bool* board, int sides, int row, int col);
 bool is_duplicate(int row, int col, int sides);
 int multiplier_for(int row, int col, int sides, bool quiet);
 #endif

--- a/helper.h
+++ b/helper.h
@@ -1,0 +1,14 @@
+#ifndef __HELPERH__
+#define __HELPERH__
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+void set_true(bool*, int, int, int);
+void set_false(bool*, int, int, int);
+void set_val(bool*, int, int, int, bool);
+bool get_visited(bool*, int, int, int);
+void print_board(bool*, int);
+bool is_duplicate(int row, int col, int sides);
+int multiplier_for(int row, int col, int sides, bool quiet);
+#endif

--- a/helper.h
+++ b/helper.h
@@ -8,7 +8,6 @@ void set_true(bool*, int, int, int);
 void set_false(bool*, int, int, int);
 void set_val(bool*, int, int, int, bool);
 bool get_visited(bool*, int, int, int);
-void print_board(bool*, int);
 bool is_duplicate(int row, int col, int sides);
 int multiplier_for(int row, int col, int sides, bool quiet);
 #endif

--- a/main.c
+++ b/main.c
@@ -1,13 +1,15 @@
+#include "getopt.h"
 #include "main.h"
 #include "solver.h"
 #include "bignum.h"
-#include "getopt.h"
 
 int main(int argc, char** argv) {
     int sides = 0;
     bool quiet_flag = false;
+    int only_row = 0;
+    int only_col = 0;
 
-    parse_opts(argc, argv, &quiet_flag, &sides);
+    parse_opts(argc, argv, &quiet_flag, &sides, &only_row, &only_col);
     if(sides <= 0) {
         help(argv[0], 1);
     }
@@ -19,15 +21,23 @@ int main(int argc, char** argv) {
     exit(0);
 }
 
-void parse_opts(int argc, char** argv, bool* quiet_flag, int* sides) {
+void parse_opts(int argc, char** argv, bool* quiet_flag, int* sides, int* only_row, int* only_col) {
     int c;
-    while((c = getopt(argc, argv, "qh")) != -1) {
+    int ret;
+    while((c = getopt(argc, argv, "qho:")) != -1) {
         switch(c) {
             case 'q':
                 *quiet_flag = true;
                 break;
             case 'h':
                 help(argv[0], 0);
+                break;
+            case 'o':
+                ret = sscanf(optarg, "%d,%d", only_col, only_row);
+                if(ret != 2 || *only_col <= 0 || *only_row <= 0) {
+                    printf("-o requires COL,ROW (indexed starting from 1)\n");
+                    help(argv[0], 1);
+                }
                 break;
             default:
                 help(argv[0], 1);
@@ -51,9 +61,30 @@ void output_bignums(int sides, bool quiet) {
 }
 
 void help(char* program_name, int code) {
-    printf("%s [-h] [-q] <SIDES>\n", program_name);
+    printf("%s [-h] [-q] [-o COL,ROW] <SIDES>\n", program_name);
     printf("   SIDES defaults to 4 if not specified\n\n");
     printf("   -q\t\tSuppress status output\n");
     printf("   -h\t\tThis help\n");
+    printf("   -o\t\tOnly solve for cell specified by COL and ROW\n");
+    printf("   \t\tBoard is indexed as follows:\n");
+    print_board(6);
     exit(code);
 }
+
+void print_board(int sides) {
+    printf("\t\t   ");
+    for(int col = 1; col <= sides; col++) {
+        printf("\e[4m%d \e[0m", col);
+    }
+    printf("\n");
+    for(int row=0; row < sides; row++) {
+        printf("\t\t%d |", row + 1);
+        for(int col=0; col < sides; col++) {
+            printf("\e[4m \e[0m");
+            printf("\e[4m|\e[0m");
+        }
+        printf("\n");
+    }
+    printf("\n");
+}
+

--- a/main.c
+++ b/main.c
@@ -13,10 +13,11 @@ int main(int argc, char** argv) {
     if(sides <= 0) {
         help(argv[0], 1);
     }
-    if(sides >= 7) {
-        output_bignums(sides, quiet_flag);
+    if(sides >= 1) {
+        output_bignums(sides, quiet_flag, only_row, only_col);
     } else {
-        printf("A board with %d sides has %llu possible solutions\n", sides, solve(sides, quiet_flag));
+        unsigned long long result = solve(sides, quiet_flag);
+        printf("A board with %d sides has %llu possible solutions\n", sides, result);
     }
     exit(0);
 }
@@ -51,11 +52,20 @@ void parse_opts(int argc, char** argv, bool* quiet_flag, int* sides, int* only_r
     }
 }
 
-void output_bignums(int sides, bool quiet) {
+void output_bignums(int sides, bool quiet, int only_row, int only_col) {
     mpz_t answer;
     mpz_init(answer);
-    solve_bignum(sides, quiet, answer);
-    printf("A board with %d sides has %s possible solutions\n", sides, mpz_get_str(NULL, 10, answer));
+    if (only_row != 0 && only_col != 0) {
+        solve_bignum_single(only_row - 1, only_col - 1, sides, quiet, answer);
+        printf("Cell (%d, %d) on a board with %d sides is the starting point of %s paths\n",
+                only_col, only_row, sides, mpz_get_str(NULL, 10, answer));
+    } else {
+        char* out_string;
+        solve_bignum(sides, quiet, answer);
+        out_string = mpz_get_str(NULL, 10, answer);
+        printf("A board with %d sides has %s possible solutions\n", sides, out_string);
+        free(out_string);
+    }
     mpz_clear(answer);
     return;
 }

--- a/main.c
+++ b/main.c
@@ -13,11 +13,18 @@ int main(int argc, char** argv) {
     if(sides <= 0) {
         help(argv[0], 1);
     }
-    if(sides >= 1) {
+    if(sides >= 7) {
         output_bignums(sides, quiet_flag, only_row, only_col);
     } else {
-        unsigned long long result = solve(sides, quiet_flag);
-        printf("A board with %d sides has %llu possible solutions\n", sides, result);
+        unsigned long long result;
+        if(only_row != 0 && only_col != 0) {
+            result = solve_single(only_row - 1, only_col - 1, sides, quiet_flag);
+            printf("Cell (%d, %d) on a board with %d sides is the starting point of %llu paths\n",
+                    only_col, only_row, sides, result);
+        } else {
+            result = solve(sides, quiet_flag);
+            printf("A board with %d sides has %llu possible solutions\n", sides, result);
+        }
     }
     exit(0);
 }

--- a/main.h
+++ b/main.h
@@ -7,5 +7,6 @@
 #include <gmp.h>
 void help(char*, int);
 void output_bignums(int, bool);
-void parse_opts(int argc, char** argv, bool*, int*);
+void parse_opts(int argc, char** argv, bool*, int*, int*, int*);
+void print_board(int);
 #endif

--- a/main.h
+++ b/main.h
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <gmp.h>
 void help(char*, int);
-void output_bignums(int, bool);
+void output_bignums(int, bool, int, int);
 void parse_opts(int argc, char** argv, bool*, int*, int*, int*);
 void print_board(int);
 #endif

--- a/main.h
+++ b/main.h
@@ -5,8 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <gmp.h>
-void help(char*, int);
-void output_bignums(int, bool, int, int);
+void help(char* program_name, int code);
+void output_bignums(int sides, bool quiet, int only_row, int only_col);
 void parse_opts(int argc, char** argv, bool*, int*, int*, int*);
-void print_board(int);
+void print_board(int sides);
 #endif

--- a/solver.c
+++ b/solver.c
@@ -1,4 +1,5 @@
 #include "solver.h"
+#include "helper.h"
 
 unsigned long long solve(int sides, bool quiet) {
     unsigned long long sum = 0;
@@ -16,9 +17,9 @@ unsigned long long solve(int sides, bool quiet) {
     }
 
     bool* visited = calloc(sides*sides, sizeof(bool));
-    for(int row = 0; row < use_rows; row++) {
-        for(int col = 0; col < use_cols; col++) {
-            if(sides_large_odd && (row == (use_rows-1) && col != (use_cols-1))) {
+    for(int row = 0; row < sides; row++) {
+        for(int col = 0; col < sides; col++) {
+            if(is_duplicate(row, col, sides)) {
                 continue;
             }
             memset(visited, 0, sizeof(bool) * sides * sides);
@@ -26,44 +27,12 @@ unsigned long long solve(int sides, bool quiet) {
             if(!quiet) {
                 printf("\tSolved square at row %d, column %d: %lld\n", row+1, col+1, adder);
             }
-            if(sides_even) {
-                if(!quiet) {
-                    printf("\t\tEven sides; square will be used four times\n");
-                }
-                adder *= 4;
-            } else if(sides_large_odd) {
-                if(row != use_rows-1 || col != use_cols-1) {
-                    if(!quiet) {
-                        printf("\t\tOdd sides; square will be used four times\n");
-                    }
-                    adder *= 4;
-                } else {
-                    if(!quiet) {
-                        printf("\t\tCenter square is only used once\n");
-                    }
-                }
-            }
+            adder *= multiplier_for(row, col, sides, quiet);
             sum += adder;
         }
     }
     free(visited);
     return(sum);
-}
-
-void print_board(bool* board, int sides) {
-    for(int row=0; row < sides; row++) {
-        printf("|");
-        for(int col=0; col < sides; col++) {
-            if(get_visited(board, sides, row, col)) {
-                printf("X");
-            } else {
-                printf(" ");
-            }
-            printf("|");
-        }
-        printf("\n");
-    }
-    printf("\n");
 }
 
 unsigned long long solve_recursive(int cur_row, int cur_col, int sides, bool* visited, unsigned long long sum) {
@@ -93,18 +62,3 @@ unsigned long long solve_recursive(int cur_row, int cur_col, int sides, bool* vi
     return(sum);
 }
 
-void set_true(bool* board, int sides, int row, int col) {
-    set_val(board, sides, row, col, true);
-}
-
-void set_false(bool* board, int sides, int row, int col) {
-    set_val(board, sides, row, col, false);
-}
-
-void set_val(bool* board, int sides, int row, int col, bool val) {
-    board[(sides * row) + col] = val;
-}
-
-bool get_visited(bool* board, int sides, int row, int col) {
-    return( board[(sides * row) + col] );
-}

--- a/solver.c
+++ b/solver.c
@@ -1,6 +1,16 @@
 #include "solver.h"
 #include "helper.h"
 
+unsigned long long solve_single(int row, int col, int sides, bool quiet) {
+    bool* visited = calloc(sides*sides, sizeof(bool));
+    if(!quiet) {
+        printf("Solving with bignums for (%d, %d) on a %dx%d grid...\n",col+1, row+1, sides, sides);
+    }
+    unsigned long long ret = solve_recursive(row, col, sides, visited, 1);
+    free(visited);
+    return ret;
+}
+
 unsigned long long solve(int sides, bool quiet) {
     unsigned long long sum = 0;
     unsigned long long adder = 1;
@@ -16,14 +26,12 @@ unsigned long long solve(int sides, bool quiet) {
         printf("Solving for %dx%d grid...\n", sides, sides);
     }
 
-    bool* visited = calloc(sides*sides, sizeof(bool));
     for(int row = 0; row < sides; row++) {
         for(int col = 0; col < sides; col++) {
             if(is_duplicate(row, col, sides)) {
                 continue;
             }
-            memset(visited, 0, sizeof(bool) * sides * sides);
-            adder = solve_recursive(row, col, sides, visited, 1);
+            adder = solve_single(row, col, sides, quiet);
             if(!quiet) {
                 printf("\tSolved square at row %d, column %d: %lld\n", row+1, col+1, adder);
             }
@@ -31,7 +39,6 @@ unsigned long long solve(int sides, bool quiet) {
             sum += adder;
         }
     }
-    free(visited);
     return(sum);
 }
 

--- a/solver.h
+++ b/solver.h
@@ -5,9 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 unsigned long long solve(int sides, bool quiet);
-unsigned long long solve_recursive(int, int, int, bool*, unsigned long long);
-void set_true(bool*, int, int, int);
-void set_false(bool*, int, int, int);
-void set_val(bool*, int, int, int, bool);
-bool get_visited(bool*, int, int, int);
+unsigned long long solve_single(int row, int col, int sides, bool quiet);
+unsigned long long solve_recursive(int row, int col, int sides, bool* visited, unsigned long long sum);
 #endif

--- a/solver.h
+++ b/solver.h
@@ -10,5 +10,4 @@ void set_true(bool*, int, int, int);
 void set_false(bool*, int, int, int);
 void set_val(bool*, int, int, int, bool);
 bool get_visited(bool*, int, int, int);
-void print_board(bool*, int);
 #endif


### PR DESCRIPTION
While performance goes down, it should only delay successive calls of `solve_single_cell`.  Since the time for this is totally swamped by time spent on `solve_recursive`, it's acceptable.

```
fsf@arm ~/boggle_paths $ make profile
rm *.o boggle_paths
gcc -std=c99 -Ofast -c -o bignum.o bignum.c
gcc -std=c99 -Ofast -c -o solver.o solver.c
gcc -std=c99 -Ofast -c -o main.o main.c
gcc -std=c99 -Ofast -c -o helper.o helper.c
gcc -std=c99 -Ofast -o boggle_paths bignum.o solver.o main.o helper.o  -lgmp
for arg in 1 2 3 4 ; do \
        echo "\n$arg sides:"; \
        time ./boggle_paths -q $arg; \
done

1 sides:
A board with 1 sides has 1 possible solutions
0.00user 0.00system 0:00.00elapsed 0%CPU (0avgtext+0avgdata 1248maxresident)k
0inputs+0outputs (0major+81minor)pagefaults 0swaps

2 sides:
A board with 2 sides has 64 possible solutions
0.00user 0.00system 0:00.00elapsed 0%CPU (0avgtext+0avgdata 1408maxresident)k
0inputs+0outputs (0major+82minor)pagefaults 0swaps

3 sides:
A board with 3 sides has 10305 possible solutions
0.00user 0.00system 0:00.00elapsed 0%CPU (0avgtext+0avgdata 1348maxresident)k
0inputs+0outputs (0major+82minor)pagefaults 0swaps

4 sides:
A board with 4 sides has 12029640 possible solutions
0.73user 0.00system 0:00.73elapsed 98%CPU (0avgtext+0avgdata 1408maxresident)k
0inputs+0outputs (0major+83minor)pagefaults 0swaps
```
